### PR TITLE
nix-remote-builder: add a proper group and make it a system user

### DIFF
--- a/nixos/roles/nix-remote-builder.nix
+++ b/nixos/roles/nix-remote-builder.nix
@@ -26,14 +26,18 @@ in
       { domain = "*"; item = "nofile"; type = "-"; value = "20480"; }
     ];
 
-    # Give restricted SSH access to the build scheduler
-    users.users.nix-remote-builder.openssh.authorizedKeys.keys = map
-      (key:
-        ''command="nix-daemon --stdio",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding ${key}''
-      )
-      cfg.schedulerPublicKeys;
-    users.users.nix-remote-builder.isNormalUser = true;
-    users.users.nix-remote-builder.group = "nogroup";
+    users.users.nix-remote-builder = {
+      isSystemUser = true;
+      group = "nix-remote-builder";
+      # Give restricted SSH access to the build scheduler
+      openssh.authorizedKeys.keys = map
+        (key:
+          ''command="nix-daemon --stdio",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding ${key}''
+        )
+        cfg.schedulerPublicKeys;
+      home = "/var/empty";
+    };
+    users.groups.nix-remote-builder = { };
     nix.settings.trusted-users = [ "nix-remote-builder" ];
   };
 }


### PR DESCRIPTION
Disclaimer: this is untested, I just saw the these things and fixed them.

- normal users show up in login manager, we don't want this for this user
- nogroup shouldn't be used for anything otherwise it becomes somegroup (i.e. multiple users could share the same group)