### PR TITLE
Disable sudo lecture

### DIFF
--- a/nixos/common/default.nix
+++ b/nixos/common/default.nix
@@ -38,6 +38,9 @@
 
   # Allow sudo from the @wheel group
   security.sudo.enable = true;
+  security.sudo.extraConfig = ''
+    Defaults lecture = never
+  '';
 
   # Ensure a clean & sparkling /tmp on fresh boots.
   boot.tmp.cleanOnBoot = lib.mkDefault true;


### PR DESCRIPTION
Whether the sudo lecture is shown is stateful. On nixos systems that don't store state you will see the sudo lecture a lot, so I find it useful to disable it