### PR TITLE
sudo: only allow exec by wheel

### DIFF
--- a/nixos/common/default.nix
+++ b/nixos/common/default.nix
@@ -10,6 +10,7 @@
     ./nix.nix
     ./openssh.nix
     ./serial.nix
+    ./sudo.nix
     ./upgrade-diff.nix
     ./well-known-hosts.nix
     ./zfs.nix
@@ -35,12 +36,6 @@
   # This is pulled in by the container profile, but it seems broken and causes
   # unecessary rebuilds.
   environment.noXlibs = false;
-
-  # Allow sudo from the @wheel group
-  security.sudo.enable = true;
-  security.sudo.extraConfig = ''
-    Defaults lecture = never
-  '';
 
   # Ensure a clean & sparkling /tmp on fresh boots.
   boot.tmp.cleanOnBoot = lib.mkDefault true;

--- a/nixos/common/sudo.nix
+++ b/nixos/common/sudo.nix
@@ -1,0 +1,10 @@
+{
+  # Allow sudo from the @wheel group
+  security.sudo.enable = true;
+  # Only allow members of the wheel group to execute sudo by setting the executable’s permissions accordingly. This prevents users that are not members of wheel from exploiting vulnerabilities in sudo such as CVE-2021-3156.
+  security.sudo.execWheelOnly = true;
+  # Don't lecture the user. Less mutable state.
+  security.sudo.extraConfig = ''
+    Defaults lecture = never
+  '';
+}


### PR DESCRIPTION
Was found in https://xeiaso.net/blog/paranoid-nixos-2021-07-18/

I'm also moving things out of the default.nix, so they can more easily be cherry-picked.