### PR TITLE
sudo: drop explicit sudo enable

### DIFF
--- a/nixos/common/sudo.nix
+++ b/nixos/common/sudo.nix
@@ -1,6 +1,4 @@
 {
-  # Allow sudo from the @wheel group
-  security.sudo.enable = true;
   # Only allow members of the wheel group to execute sudo by setting the executable’s permissions accordingly. This prevents users that are not members of wheel from exploiting vulnerabilities in sudo such as CVE-2021-3156.
   security.sudo.execWheelOnly = true;
   # Don't lecture the user. Less mutable state.


### PR DESCRIPTION
This makes it harder to replace sudo with sudo-rs