### PR TITLE
hardware-hetzner-cloud-arm: enable early console

### DIFF
--- a/nixos/hardware/hetzner-cloud/arm.nix
+++ b/nixos/hardware/hetzner-cloud/arm.nix
@@ -9,5 +9,11 @@
     boot.loader.timeout = 30;
     # since it's a vm, we can do this on every update safely
     boot.loader.efi.canTouchEfiVariables = true;
+
+    # set console because the console defaults to serial and
+    # initialize the display early to get a complete log.
+    # this is required for typing in LUKS passwords on boot too.
+    boot.kernelParams = [ "console=tty" ];
+    boot.initrd.kernelModules = [ "virtio_gpu" ];
   };
 }


### PR DESCRIPTION
This fixes the console being unavailable during early boot on Hetzner Cloud ARM servers.
It is required to be able to enter a LUKS password during boot.
