### PR TITLE
openssh: don't force authorizedKeysFiles if forgejo is enabled

### DIFF
--- a/nixos/common/openssh.nix
+++ b/nixos/common/openssh.nix
@@ -21,7 +21,12 @@
     # However those match blocks cannot be put after other `extraConfig` lines
     # with the current sshd config module, which is however something the sshd
     # config parser mandates.
-    authorizedKeysFiles = lib.mkIf (!config.services.gitea.enable && !config.services.gitlab.enable && !config.services.gitolite.enable && !config.services.gerrit.enable)
+    authorizedKeysFiles = lib.mkIf
+      (!config.services.gitea.enable
+        && !config.services.gitlab.enable
+        && !config.services.gitolite.enable
+        && !config.services.gerrit.enable
+        && !config.services.forgejo.enable)
       (lib.mkForce [ "/etc/ssh/authorized_keys.d/%u" ]);
 
     # unbind gnupg sockets if they exists


### PR DESCRIPTION
Forgejo is a fork of gitea and needs the same exception.