### PR TITLE
cloud-init: set network config to silence warning

### DIFF
--- a/nixos/mixins/cloud-init.nix
+++ b/nixos/mixins/cloud-init.nix
@@ -9,6 +9,9 @@
       enable = lib.mkDefault (lib.any (fs: fs.fsType == fsName) (lib.attrValues config.fileSystems));
     }));
 
+  networking.useNetworkd = lib.mkDefault true;
+  networking.useDHCP = lib.mkDefault false;
+
   # Delegate the hostname setting to cloud-init by default
   networking.hostName = lib.mkDefault "";
 }


### PR DESCRIPTION
https://buildbot.nix-community.org/#/builders/11/builds/55/steps/2/logs/stdio
> trace: warning: The combination of `systemd.network.enable = true`, `networking.useDHCP = true` and `networking.useNetworkd = false` can cause both networkd and dhcpcd to manage the same interfaces. This can lead to loss of networking. It is recommended you choose only one of networkd (by also enabling `networking.useNetworkd`) or scripting (by disabling `systemd.network.enable`)
