### PR TITLE
ci: remove `max-jobs = 0`

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,7 +22,6 @@ jobs:
           extra_nix_config: |
             accept-flake-config = true
             experimental-features = nix-command flakes
-            max-jobs = 0
 
       - name: Build
         id: build


### PR DESCRIPTION
Not on the nix community buildbot so the cache isn't available, I'd already removed the nixConfig but forgot this.