### PR TITLE
cloud-init: don't flush the host's ssh keys

### DIFF
--- a/nixos/mixins/cloud-init.nix
+++ b/nixos/mixins/cloud-init.nix
@@ -3,6 +3,11 @@
   services.cloud-init = {
     enable = lib.mkDefault true;
     network.enable = lib.mkDefault true;
+
+    # Never flush the host's SSH keys. See #148. Since we build the images
+    # using NixOS, that kind of issue shouldn't happen to us.
+    settings.ssh_deletekeys = lib.mkDefault false;
+
     ## Automatically enable the filesystems that are used
   } // (lib.genAttrs ([ "btrfs" "ext4" ] ++ lib.optional (lib.versionAtLeast (lib.versions.majorMinor lib.version) "23.11") "xfs")
     (fsName: {


### PR DESCRIPTION
Fixes #148