### PR TITLE
telegraf: use list for inputs.prometheus

### DIFF
--- a/nixos/mixins/telegraf.nix
+++ b/nixos/mixins/telegraf.nix
@@ -88,11 +88,10 @@ in
     extraConfig = {
       agent.interval = "60s";
       inputs = {
-        prometheus.urls = lib.mkIf config.services.promtail.enable [
-          # default promtail port
-          "http://localhost:9080/metrics"
-        ];
-        prometheus.metric_version = 2;
+        prometheus = lib.mkIf config.services.promtail.enable [{
+          urls = [ "http://localhost:9080/metrics" ]; # default promtail port
+          metric_version = 2;
+        }];
         kernel_vmstat = { };
         nginx.urls = lib.mkIf config.services.nginx.statusPage [
           "http://localhost/nginx_status"


### PR DESCRIPTION
This makes it a bit more flexible, e.g. if you need another prometheus input which uses tls client auth.