### PR TITLE
hetzner-cloud/arm: remove boot.loader.timeout

### DIFF
--- a/nixos/hardware/hetzner-cloud/arm.nix
+++ b/nixos/hardware/hetzner-cloud/arm.nix
@@ -6,7 +6,6 @@
   config = {
     # arm uses EFI, so we need systemd-boot
     boot.loader.systemd-boot.enable = true;
-    boot.loader.timeout = 30;
     # since it's a vm, we can do this on every update safely
     boot.loader.efi.canTouchEfiVariables = true;
 


### PR DESCRIPTION
This timeout seems to be quite arbitrary, it is not specifically required for Hetzner ARM VMs.