### PR TITLE
Revert "common/openssh: apply workaround for CVE-2024-6387"

### DIFF
--- a/nixos/common/openssh.nix
+++ b/nixos/common/openssh.nix
@@ -9,11 +9,6 @@
     # unbind gnupg sockets if they exists
     settings.StreamLocalBindUnlink = true;
 
-    # We might want to remove this once, openssh is fixed everywhere:
-    # Workaround for CVE-2024-6387
-    # https://github.com/NixOS/nixpkgs/pull/323753#issuecomment-2199762128
-    settings.LoginGraceTime = 0;
-
     # Use key exchange algorithms recommended by `nixpkgs#ssh-audit`
     settings.KexAlgorithms = [
       "curve25519-sha256"


### PR DESCRIPTION
This reverts commit b742b86532b2fba82e42acd106419d0d7419ed4f.

Bumped the inputs in https://github.com/nix-community/srvos/pull/450 for anyone following the srvos nixpkgs inputs.