### PR TITLE
disable auto-allocate-uids on macOS

### DIFF
--- a/darwin/mixins/nix-experimental.nix
+++ b/darwin/mixins/nix-experimental.nix
@@ -2,9 +2,6 @@
 {
   # Enable flakes
   nix.settings.experimental-features = [
-    # nix-daemon will allocate users rather than making them part of the /etc/passwd
-    "auto-allocate-uids"
-
     # Enable the use of the fetchClosure built-in function in the Nix language.
     "fetch-closure"
 
@@ -13,9 +10,6 @@
   ] ++ lib.optional (lib.versionAtLeast (lib.versions.majorMinor config.nix.package.version) "2.19")
     # Allow the use of the impure-env setting.
     "configurable-impure-env";
-
-  # no longer need to pre-allocate build users for everything
-  nix.settings.auto-allocate-uids = true;
 
   # for container in builds support
   nix.settings.system-features = lib.mkDefault [ "uid-range" ];


### PR DESCRIPTION
It breaks whoami in nix builds.