### PR TITLE
hetzner-cloud: enable qemu-agent for password resets

### DIFF
--- a/docs/nixos/hardware.md
+++ b/docs/nixos/hardware.md
@@ -20,7 +20,9 @@ Enables cloud-init but turns of non-working dhcp.
 
 Hardware configuration for <https://www.hetzner.com/cloud> instances.
 
-The main difference here is that cloud-init is enabled.
+The main difference here is that:
+1. cloud-init is enabled.
+2. the qemu agent is running, to allow password reset to function.
 
 ### `nixosModules.hardware-hetzner-cloud-arm`
 

--- a/nixos/hardware/hetzner-cloud/default.nix
+++ b/nixos/hardware/hetzner-cloud/default.nix
@@ -1,4 +1,4 @@
-{ config, modulesPath, lib, ... }:
+{ config, modulesPath, lib, pkgs, ... }:
 {
   imports = [
     ../../mixins/cloud-init.nix
@@ -13,5 +13,10 @@
 
     networking.useNetworkd = true;
     networking.useDHCP = false;
+
+    # Needed by the Hetzner Cloud password reset feature.
+    services.qemuGuest.enable = lib.mkDefault true;
+    # https://discourse.nixos.org/t/qemu-guest-agent-on-hetzner-cloud-doesnt-work/8864/2
+    systemd.services.qemu-guest-agent.path = [ pkgs.shadow ];
   };
 }


### PR DESCRIPTION
This is useful to log in using the VNC console.

Tested, works as expected
