### PR TITLE
fix vim warning

### DIFF
--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -33,7 +33,11 @@
   # No need for fonts on a server
   fonts.fontconfig.enable = lib.mkDefault false;
 
-  programs.vim.defaultEditor = lib.mkDefault true;
+  programs.vim = {
+    defaultEditor = lib.mkDefault true;
+  } // lib.optionalAttrs (lib.versionAtLeast (lib.versions.majorMinor lib.version) "24.11") {
+    enable = lib.mkDefault true;
+  };
 
   # Make sure firewall is enabled
   networking.firewall.enable = true;


### PR DESCRIPTION
> programs.vim.defaultEditor will only work if programs.vim.enable is enabled, which will be enforced after the 24.11 release