### PR TITLE
darwin: drop removed services.openssh.authorizedKeysFiles option

### DIFF
--- a/darwin/common/openssh.nix
+++ b/darwin/common/openssh.nix
@@ -12,6 +12,4 @@
     # Use key exchange algorithms recommended by `nixpkgs#ssh-audit`
     KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,sntrup761x25519-sha512@openssh.com
   '';
-  # Only allow system-level authorized_keys to avoid injections.
-  services.openssh.authorizedKeysFiles = lib.mkForce [ "/etc/ssh/authorized_keys.d/%u" ];
 }


### PR DESCRIPTION
nix-darwin no longer allow to set this due to a security issue found in the implementation: https://github.com/LnL7/nix-darwin/commit/b833d4a32d965e6393a63b2c91b46eca2a5030d8

Fixes #456 