### PR TITLE
feat(server): restrict boot entries to 5

### DIFF
--- a/nixos/mixins/systemd-boot.nix
+++ b/nixos/mixins/systemd-boot.nix
@@ -1,11 +1,11 @@
 # Add this mixin to machines that boot with EFI
+{ lib, ... }:
 {
-
   # Only enable during install
   #boot.loader.efi.canTouchEfiVariables = true;
 
   # Use systemd-boot to boot EFI machines
-  boot.loader.systemd-boot.configurationLimit = 10;
+  boot.loader.systemd-boot.configurationLimit = lib.mkOverride 1337 10;
   boot.loader.systemd-boot.enable = true;
   boot.loader.timeout = 3;
 }

--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -27,6 +27,12 @@
     stub-ld.enable = lib.mkDefault false;
   };
 
+  # Restrict the number of boot entries to prevent full /boot partition.
+  #
+  # Servers don't need too many generations.
+  boot.loader.grub.configurationLimit = lib.mkDefault 5;
+  boot.loader.systemd-boot.configurationLimit = lib.mkDefault 5;
+
   # Notice this also disables --help for some commands such es nixos-rebuild
   documentation.enable = lib.mkDefault false;
   documentation.info.enable = lib.mkDefault false;


### PR DESCRIPTION
Avoid the full /boot partition issue by limiting the number of entries to add in said partition.

Since a boot entry (bzImage + initrd) is around 32MiB, this require the /boot partition to be at least 160MiB in size, 260MiB+ recommended (for the block sizes).

Ref: <https://www.ctrl.blog/entry/esp-size-guide.html>