### PR TITLE
feat(zfs): set default networking.hostId

### DIFF
--- a/nixos/common/zfs.nix
+++ b/nixos/common/zfs.nix
@@ -3,6 +3,9 @@
   # You may also find this setting useful to automatically set the latest compatible kernel:
   #boot.kernelPackages = config.boot.zfs.package.latestCompatibleLinuxPackages;
 
+  # Use the same default hostID as the NixOS install ISO and nixos-anywhere.
+  networking.hostId = lib.mkDefault "8425e349";
+
   services.zfs = lib.mkIf (config.boot.zfs.enabled) {
     autoSnapshot.enable = true;
     # defaults to 12, which is a bit much given how much data is written

--- a/nixos/common/zfs.nix
+++ b/nixos/common/zfs.nix
@@ -4,6 +4,10 @@
   #boot.kernelPackages = config.boot.zfs.package.latestCompatibleLinuxPackages;
 
   # Use the same default hostID as the NixOS install ISO and nixos-anywhere.
+  # This allows us to import zfs pool without using a force import.
+  # ZFS has this as a safety mechanism for networked block storage (ISCSI), but 
+  # in practice we found it causes more breakages like unbootable machines,
+  # while people using ZFS on ISCSI is quite rare.
   networking.hostId = lib.mkDefault "8425e349";
 
   services.zfs = lib.mkIf (config.boot.zfs.enabled) {


### PR DESCRIPTION
In server scenario, disks are not getting shared, this is just not a thing. Don't force users to set this value.