### PR TITLE
break(nix): disable nix channels

### DIFF
--- a/nixos/common/nix.nix
+++ b/nixos/common/nix.nix
@@ -1,7 +1,10 @@
 { lib, config, ... }:
 {
+  # Disable nix channels. Use flakes instead.
+  nix.channel.enable = lib.mkDefault false;
+
   # Fallback quickly if substituters are not available.
-  nix.settings.connect-timeout = 5;
+  nix.settings.connect-timeout = lib.mkDefault 5;
 
   # Enable flakes
   nix.settings.experimental-features = [


### PR DESCRIPTION
Channels are not reproducible and should be removed.

This change:
* removes the `nix-channel` binary
* sets an empty NIX_PATH
* stop adding the /root/.nix-channels file

This will lead scripts depending on channels to break, exposing their dependency on channels.