### PR TITLE
modules/github-runners: encode nix-daemon's dependency on runners

### DIFF
--- a/nixos/modules/github-runners/default.nix
+++ b/nixos/modules/github-runners/default.nix
@@ -73,5 +73,6 @@ in
         )
       )
     );
+    systemd.services.nix-daemon.after = map (name: "${name}.service") (attrNames cfg);
   };
 }


### PR DESCRIPTION
Runners should be able to access nix-daemon so as to build using nix.

Services started after nix-daemon cannot access the nix store; runners use dynamic users which makes 'nix.settings.allowed-users' prone to failures.

See https://github.com/nix-community/srvos/issues/473