### PR TITLE
chore(flake): update mkdocs-numtide

### DIFF
--- a/dev/private.narHash
+++ b/dev/private.narHash
@@ -1,1 +1,1 @@
-sha256-fTaaWYyjC8CZpLRG/O4dLtxFVyvdzF1K/Y3OcvA+IiQ=
+sha256-ktBO400Wuea/qB+gGDrTY/HoQFINjONZPWXkziJhYvs=

--- a/dev/private/flake.lock
+++ b/dev/private/flake.lock
@@ -58,16 +58,14 @@
     },
     "mkdocs-numtide": {
       "inputs": {
-        "nixpkgs": [
-          "nixos-stable"
-        ]
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1687786869,
-        "narHash": "sha256-KhaNnOTjj9FgPLtRHTFGa1RFXvSc+nF1UPcBiYf/CCY=",
+        "lastModified": 1722954520,
+        "narHash": "sha256-tRW6zKvxLaD2Xejm0gumtXMIw70+1Zp58LbRBaGvHlA=",
         "owner": "numtide",
         "repo": "mkdocs-numtide",
-        "rev": "b3008171c75083f2bf2f1dc4e6781d4737dfaa49",
+        "rev": "5cab0db44c728b0152187a439dec642e8ec1c72b",
         "type": "github"
       },
       "original": {
@@ -106,6 +104,22 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1722185531,
+        "narHash": "sha256-veKR07psFoJjINLC8RK4DiLniGGMgF3QMlS4tb74S6k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "52ec9ac3b12395ad677e8b62106f0b98c1f8569d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/dev/private/flake.nix
+++ b/dev/private/flake.nix
@@ -7,7 +7,6 @@
   inputs.nix-darwin.inputs.nixpkgs.follows = "";
 
   inputs.mkdocs-numtide.url = "github:numtide/mkdocs-numtide";
-  inputs.mkdocs-numtide.inputs.nixpkgs.follows = "nixos-stable";
 
   inputs.treefmt-nix.url = "github:numtide/treefmt-nix";
   inputs.treefmt-nix.inputs.nixpkgs.follows = "";


### PR DESCRIPTION
Unfollow nixos-stable since mkdocs-numtide depends on a plugin that is only available on nixos-unstable.