### PR TITLE
initrd.systemd: disable emergency mode

### DIFF
--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -1,6 +1,7 @@
 # A default configuration that applies to all servers.
 # Common configuration across *all* the machines
 {
+  config,
   pkgs,
   lib,
   options,

--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -73,6 +73,14 @@
   # No mutable users by default
   users.mutableUsers = false;
 
+  # Given that our systems are headless, emergency mode is useless.
+  # We prefer the system to attempt to continue booting so
+  # that we can hopefully still access it remotely.
+  boot.initrd.systemd.suppressedUnits = [
+    "emergency.service"
+    "emergency.target"
+  ];
+
   systemd = {
     # Given that our systems are headless, emergency mode is useless.
     # We prefer the system to attempt to continue booting so

--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -76,7 +76,7 @@
   # Given that our systems are headless, emergency mode is useless.
   # We prefer the system to attempt to continue booting so
   # that we can hopefully still access it remotely.
-  boot.initrd.systemd.suppressedUnits = [
+  boot.initrd.systemd.suppressedUnits = lib.mkIf config.systemd.enableEmergencyMode [
     "emergency.service"
     "emergency.target"
   ];


### PR DESCRIPTION
we disable emergency mode in systemd, but if systemd is enabled during boot we still end up in emergency mode eventually, this will fix that.