### PR TITLE
fix: set lower prio on networking.hostName

### DIFF
--- a/nixos/mixins/cloud-init.nix
+++ b/nixos/mixins/cloud-init.nix
@@ -26,5 +26,5 @@
   networking.useDHCP = lib.mkDefault false;
 
   # Delegate the hostname setting to cloud-init by default
-  networking.hostName = lib.mkOverride 1337 "";
+  networking.hostName = lib.mkOverride 1337 ""; # lower prio than lib.mkDefault
 }

--- a/nixos/mixins/cloud-init.nix
+++ b/nixos/mixins/cloud-init.nix
@@ -26,5 +26,5 @@
   networking.useDHCP = lib.mkDefault false;
 
   # Delegate the hostname setting to cloud-init by default
-  networking.hostName = lib.mkDefault "";
+  networking.hostName = lib.mkOverride 1337 "";
 }

--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -43,7 +43,7 @@
   networking.firewall.enable = true;
 
   # Delegate the hostname setting to dhcp/cloud-init by default
-  networking.hostName = lib.mkDefault "";
+  networking.hostName = lib.mkOverride 1337 "";
 
   # If the user is in @wheel they are trusted by default.
   nix.settings.trusted-users = [

--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -43,7 +43,7 @@
   networking.firewall.enable = true;
 
   # Delegate the hostname setting to dhcp/cloud-init by default
-  networking.hostName = lib.mkOverride 1337 "";
+  networking.hostName = lib.mkOverride 1337 ""; # lower prio than lib.mkDefault
 
   # If the user is in @wheel they are trusted by default.
   nix.settings.trusted-users = [


### PR DESCRIPTION
Avoid clashes with the clan-core project.

1337 is in between mkDefault (1000) and mkOptionDefault (1500).