### PR TITLE
dev/private/flake: add nixpkgs-dev input

### DIFF
--- a/dev/private.narHash
+++ b/dev/private.narHash
@@ -1,1 +1,1 @@
-sha256-0I0qqgz3Ec+tkr1ZRO9f1tMNuZ24DSSFZwWFjwld6tw=
+sha256-+VposzihPwYxnFr+6QYagW6B7xIH8txv0iNQQfo2bbU=

--- a/dev/private/flake.lock
+++ b/dev/private/flake.lock
@@ -18,7 +18,7 @@
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
-          "nixos-stable"
+          "nixpkgs-dev"
         ]
       },
       "locked": {
@@ -58,7 +58,9 @@
     },
     "mkdocs-numtide": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs-dev"
+        ]
       },
       "locked": {
         "lastModified": 1722954520,
@@ -108,18 +110,18 @@
         "type": "github"
       }
     },
-    "nixpkgs": {
+    "nixpkgs-dev": {
       "locked": {
-        "lastModified": 1722185531,
-        "narHash": "sha256-veKR07psFoJjINLC8RK4DiLniGGMgF3QMlS4tb74S6k=",
+        "lastModified": 1724265050,
+        "narHash": "sha256-RbWuBZn2QYNRPgfrQLtj7/AMEXOmlLT+kduufdmcRP8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "52ec9ac3b12395ad677e8b62106f0b98c1f8569d",
+        "rev": "e590723c5186bdad64e3cdaf9ed72cb984caa48e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-unstable-small",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -154,6 +156,7 @@
         "mkdocs-numtide": "mkdocs-numtide",
         "nix-darwin": "nix-darwin",
         "nixos-stable": "nixos-stable",
+        "nixpkgs-dev": "nixpkgs-dev",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "treefmt-nix": "treefmt-nix"
       }

--- a/dev/private/flake.nix
+++ b/dev/private/flake.nix
@@ -1,12 +1,16 @@
 {
   description = "srvos private inputs";
 
+  # follows the same channel as nixpkgs in the main flake
+  inputs.nixpkgs-dev.url = "github:NixOS/nixpkgs/nixos-unstable-small";
+
   inputs.nixos-stable.url = "github:NixOS/nixpkgs/nixos-24.05";
 
   inputs.nix-darwin.url = "github:LnL7/nix-darwin";
   inputs.nix-darwin.inputs.nixpkgs.follows = "";
 
   inputs.mkdocs-numtide.url = "github:numtide/mkdocs-numtide";
+  inputs.mkdocs-numtide.inputs.nixpkgs.follows = "nixpkgs-dev";
 
   inputs.treefmt-nix.url = "github:numtide/treefmt-nix";
   inputs.treefmt-nix.inputs.nixpkgs.follows = "";
@@ -17,7 +21,7 @@
   inputs.pre-commit-hooks-nix.inputs.nixpkgs-stable.follows = "";
 
   inputs.flake-parts.url = "github:hercules-ci/flake-parts";
-  inputs.flake-parts.inputs.nixpkgs-lib.follows = "nixos-stable";
+  inputs.flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs-dev";
 
   inputs.flake-compat.url = "github:nix-community/flake-compat";
 


### PR DESCRIPTION
One less nixpkgs input, everything is either on nixos-unstable-small or nixos-unstable.