### PR TITLE
fix(nix-remote-builder): allow more connections

### DIFF
--- a/nixos/roles/nix-remote-builder.nix
+++ b/nixos/roles/nix-remote-builder.nix
@@ -42,5 +42,8 @@ in
     users.users.nix-remote-builder.isNormalUser = true;
     users.users.nix-remote-builder.group = "nogroup";
     nix.settings.trusted-users = [ "nix-remote-builder" ];
+
+    # Allow more nix-daemon sessions to connect at the same time.
+    services.openssh.settings.MaxStartups = 100;
   };
 }


### PR DESCRIPTION
Given the nix-daemon forking model, it can starve the remote builder of connections. Bump the limits.

See also https://github.com/nix-community/infra/pull/1417