### PR TITLE
{hetzner-cloud, vultr}: don't conflict with disko

### DIFF
--- a/nixos/hardware/hetzner-cloud/default.nix
+++ b/nixos/hardware/hetzner-cloud/default.nix
@@ -13,7 +13,7 @@
 
   config = {
     boot.growPartition = true;
-    boot.loader.grub.device = "/dev/sda";
+    boot.loader.grub.devices = lib.mkDefault [ "/dev/sda" ];
 
     fileSystems."/" = lib.mkDefault {
       device = "/dev/sda1";

--- a/nixos/hardware/vultr/vm.nix
+++ b/nixos/hardware/vultr/vm.nix
@@ -1,4 +1,4 @@
-{ modulesPath, ... }:
+{ modulesPath, lib, ... }:
 {
   imports = [
     ./.
@@ -7,5 +7,5 @@
   ];
 
   boot.loader.grub.enable = true;
-  boot.loader.grub.devices = [ "/dev/vda" ];
+  boot.loader.grub.devices = lib.mkDefault [ "/dev/vda" ];
 }

--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -1,6 +1,11 @@
 # A default configuration that applies to all servers.
 # Common configuration across *all* the machines
-{ pkgs, lib, ... }:
+{
+  pkgs,
+  lib,
+  options,
+  ...
+}:
 {
 
   imports = [ ../common ];
@@ -35,7 +40,7 @@
     {
       defaultEditor = lib.mkDefault true;
     }
-    // lib.optionalAttrs (lib.versionAtLeast (lib.versions.majorMinor lib.version) "24.11") {
+    // lib.optionalAttrs (options.programs.vim ? enable) {
       enable = lib.mkDefault true;
     };
 


### PR DESCRIPTION
boot.loader.grub.device maps internally to boot.loader.grub.devices. Disko only sets boot.loader.grub.devices. By using the default priority we allow disko to override this value.

fixes https://github.com/nix-community/disko/issues/748