### PR TITLE
Add assertion for custom sudo rules

### DIFF
--- a/nixos/common/sudo.nix
+++ b/nixos/common/sudo.nix
@@ -1,3 +1,4 @@
+{ config, ... }:
 {
   # Only allow members of the wheel group to execute sudo by setting the executable’s permissions accordingly. This prevents users that are not members of wheel from exploiting vulnerabilities in sudo such as CVE-2021-3156.
   security.sudo.execWheelOnly = true;
@@ -5,4 +6,19 @@
   security.sudo.extraConfig = ''
     Defaults lecture = never
   '';
+
+  assertions =
+    let
+      validUsers = users: users == [ ] || users == [ "root" ];
+      validGroups = groups: groups == [ ] || groups == [ "wheel" ];
+      validUserGroups = builtins.all (
+        r: validUsers (r.users or [ ]) && validGroups (r.groups or [ ])
+      ) config.security.sudo.extraRules;
+    in
+    [
+      {
+        assertion = config.security.sudo.execWheelOnly -> validUserGroups;
+        message = "Some definitions in `security.sudo.extraRules` refer to users other than 'root' or groups other than 'wheel'. Disable `config.security.sudo.execWheelOnly`, or adjust the rules.";
+      }
+    ];
 }


### PR DESCRIPTION
I added custom rules to by sudo to allow a single user to restart a service.

Since srvos enables `security.sudo.execWheelOnly` by default, this breaks such use cases and it took me a while to debug it until I found out about this option.

Basically any sudo rule declared on anything else than `root` or `wheel` will not have any effect until this option is disabled again.

I now added an assertion to check for this scenario and crash with a nice error telling you to disable `execWheelOnly` if you declared any such rules