### PR TITLE
no longer set networking.useDHCP to false

### DIFF
--- a/nixos/common/networking.nix
+++ b/nixos/common/networking.nix
@@ -9,7 +9,6 @@
 
   # Use networkd instead of the pile of shell scripts
   networking.useNetworkd = lib.mkDefault true;
-  networking.useDHCP = lib.mkDefault false;
 
   # The notion of "online" is a broken concept
   # https://github.com/systemd/systemd/blob/e1b45a756f71deac8c1aa9a008bd0dab47f64777/NEWS#L13


### PR DESCRIPTION
This was originally intended to disable scripted networking, but it's actually also an option that systemd-networkd respects. So we shouldn't have it.