### PR TITLE
Set watchdog for kexec to prevent hanging in case of missing firmware support

### DIFF
--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -109,6 +109,9 @@
       # For more info, see:
       #   https://utcc.utoronto.ca/~cks/space/blog/linux/SystemdShutdownWatchdog
       rebootTime = "30s";
+      # Forcefully reboot when a host hangs after kexec.
+      # This may be the case when the firmware does not support kexec.
+      kexecTime = "1m";
     };
 
     sleep.extraConfig = ''


### PR DESCRIPTION
There are hosts that cannot successfully perform a kexec and get stuck because no watchdog watches it. Timeout of `1m` is debatable.