### PR TITLE
Disable docs, too

### DIFF
--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -36,6 +36,7 @@
 
   # Notice this also disables --help for some commands such es nixos-rebuild
   documentation.enable = lib.mkDefault false;
+  documentation.doc.enable = lib.mkDefault false;
   documentation.info.enable = lib.mkDefault false;
   documentation.man.enable = lib.mkDefault false;
   documentation.nixos.enable = lib.mkDefault false;


### PR DESCRIPTION
If we have no man pages, we surely don't need the doc output or path.