### PR TITLE
darwin: move nix.daemonIOLowPriority to desktop

### DIFF
--- a/darwin/common/nix.nix
+++ b/darwin/common/nix.nix
@@ -13,6 +13,4 @@
       Minute = 45;
     }
   ];
-
-  nix.daemonIOLowPriority = lib.mkDefault true;
 }

--- a/darwin/desktop/default.nix
+++ b/darwin/desktop/default.nix
@@ -1,1 +1,6 @@
-{ imports = [ ../common ]; }
+{ lib, ... }:
+{
+  imports = [ ../common ];
+
+  nix.daemonIOLowPriority = lib.mkDefault true;
+}


### PR DESCRIPTION
I think this is probably better suited for the desktop module like a similar nixos setting:

https://github.com/nix-community/srvos/blob/b7aa1d742955cfb96615d380f02049ec67f5abc0/nixos/desktop/default.nix#L12-L13