### PR TITLE
darwin: disable AuthorizedKeysFile

### DIFF
--- a/darwin/common/openssh.nix
+++ b/darwin/common/openssh.nix
@@ -2,6 +2,11 @@
 { lib, ... }:
 {
   environment.etc."ssh/sshd_config.d/102-srvos.conf".text = ''
+    # Only allow system-level authorized_keys to avoid injections.
+    # nix-darwin uses AuthorizedKeysCommand to set system-level keys
+    # https://github.com/LnL7/nix-darwin/blob/f61d5f2051a387a15817007220e9fb3bbead57b3/modules/programs/ssh/default.nix#L158
+    AuthorizedKeysFile none
+
     X11Forwarding no
     KbdInteractiveAuthentication no
     PasswordAuthentication no


### PR DESCRIPTION
this is the equivalent of the setting that was removed in 9c9db0b387e7919ec13d6f4d762d4088c0c2d180