### PR TITLE
mdns: enable for all useDHCP interfaces

### DIFF
--- a/nixos/mixins/mdns.nix
+++ b/nixos/mixins/mdns.nix
@@ -1,10 +1,21 @@
 { config, lib, ... }:
+let
+  mapInterfaceEnabled = i: lib.nameValuePair "40-${i.name}" i.useDHCP;
+  mapMDNSConfig = enableMDNS: {
+    networkConfig.MulticastDNS = lib.mkDefault enableMDNS;
+  };
+
+  configs = {
+    "99-ethernet-default-dhcp" = config.networking.useDHCP;
+    "99-wireless-client-dhcp" = config.networking.useDHCP;
+  } // (lib.mapAttrs' (_: mapInterfaceEnabled) config.networking.interfaces);
+in
 {
   # Avahi is an alternative implementation. If it's enabled, than we don't need the code below.
   config = lib.mkIf (!config.services.avahi.enable) {
-    # Allows to find machines on the local network by name, i.e. useful for printer discovery
-    systemd.network.networks."99-ethernet-default-dhcp".networkConfig.MulticastDNS = lib.mkDefault "yes";
-    systemd.network.networks."99-wireless-client-dhcp".networkConfig.MulticastDNS = lib.mkDefault "yes";
     networking.firewall.allowedUDPPorts = [ 5353 ]; # Multicast DNS
+
+    # Allows to find machines on the local network by name, i.e. useful for printer discovery
+    systemd.network.networks = builtins.mapAttrs (_: mapMDNSConfig) configs;
   };
 }


### PR DESCRIPTION
`nixos/modules/tasks/network-interfaces-systemd.nix` only creates networkd networks if `useDHCP` is enabled. This is the case for the global setting, as well as the per-interface setting.

This commit only enables the multicast option globally if `useDHCP` is enabled globally. Additionally it enables MulticastDNS for each interface that has `useDHCP` enabled.
