### PR TITLE
zfs: drop 'latestCompatibleLinuxPackages'

### DIFF
--- a/nixos/common/zfs.nix
+++ b/nixos/common/zfs.nix
@@ -1,8 +1,5 @@
 { config, lib, ... }:
 {
-  # You may also find this setting useful to automatically set the latest compatible kernel:
-  #boot.kernelPackages = config.boot.zfs.package.latestCompatibleLinuxPackages;
-
   # Use the same default hostID as the NixOS install ISO and nixos-anywhere.
   # This allows us to import zfs pool without using a force import.
   # ZFS has this as a safety mechanism for networked block storage (ISCSI), but 


### PR DESCRIPTION
## description

exactly what it says in the commit message: this config field has been deprecated as of 24.11.

since it was only ever a commented out suggestion, it should be safe to remove even before `srvos` updates its nixpkgs snapshot.