### PR TITLE
server/networking: unset tcp BBR and fq

### DIFF
--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -111,12 +111,6 @@
     '';
   };
 
-  # use TCP BBR has significantly increased throughput and reduced latency for connections
-  boot.kernel.sysctl = {
-    "net.core.default_qdisc" = "fq";
-    "net.ipv4.tcp_congestion_control" = "bbr";
-  };
-
   # Make sure the serial console is visible in qemu when testing the server configuration
   # with nixos-rebuild build-vm
   virtualisation.vmVariant.virtualisation.graphics = lib.mkDefault false;


### PR DESCRIPTION
Appearantly TCP BBR is not a good idea without doing any performance measurements: https://github.com/nix-community/srvos/pull/556

fq is actually incorrect. It should be `fq_codel` and systemd already applies this by default for us.