### PR TITLE
 chore: move update-private-narhash to script 

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -33,7 +33,7 @@ jobs:
           pushd dev/private
           nix flake update --commit-lock-file
           popd
-          nix run .#update-dev-private-narHash
+          ./dev/update-private-narhash
           git commit --amend --no-edit dev/private.narHash
       - uses: peter-evans/create-pull-request@v7
         with:

--- a/dev/default.nix
+++ b/dev/default.nix
@@ -58,19 +58,12 @@
       devShells = lib.optionalAttrs defaultPlatform {
         mkdocs = pkgs.mkShellNoCC { packages = [ inputs.mkdocs-numtide.packages.${system}.default ]; };
       };
-      packages =
-        {
-          update-dev-private-narHash = pkgs.writeShellScriptBin "update-dev-private-narHash" ''
-            nix flake lock ./dev/private
-            nix hash path ./dev/private > ./dev/private.narHash
-          '';
-        }
-        // lib.optionalAttrs defaultPlatform {
-          docs = inputs.mkdocs-numtide.lib.${system}.mkDocs {
-            name = "srvos";
-            src = self;
-          };
+      packages = lib.optionalAttrs defaultPlatform {
+        docs = inputs.mkdocs-numtide.lib.${system}.mkDocs {
+          name = "srvos";
+          src = self;
         };
+      };
       pre-commit = {
         check.enable = defaultPlatform;
         settings.hooks.dev-private-narHash = {

--- a/dev/update-private-narhash
+++ b/dev/update-private-narhash
@@ -6,7 +6,7 @@ cd "$(dirname "$0")"
 
 echo "Updating $PWD/private.narHash" >&2
 
-nix flake lock ./private
-nix hash path ./private > ./private.narHash
+nix --extra-experimental-flags 'flakes nix-command' flake lock ./private
+nix --extra-experimental-flags 'flakes nix-command' hash path ./private > ./private.narHash
 
 echo OK

--- a/dev/update-private-narhash
+++ b/dev/update-private-narhash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Used to update the private dev flake hash reference.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+echo "Updating $PWD/private.narHash" >&2
+
+nix flake lock ./private
+nix hash path ./private > ./private.narHash
+
+echo OK


### PR DESCRIPTION
The issue with the current dev-flake setup is that `builtins.getFlake`
is not available in Nix, unless flakes are enabled. So this idea
of using flake-compat doesn't work.

Since the project is exporting modules, it doesn't matter. Replace the
top-level default.nix flake-compat with a simple attrset.