### PR TITLE
common/flake: include cfg.flake in telegraf inputs

### DIFF
--- a/shared/common/flake.nix
+++ b/shared/common/flake.nix
@@ -57,7 +57,9 @@ in
 
     services.telegraf.extraConfig.inputs.file =
       let
-        inputsWithDate = lib.filterAttrs (_: input: input ? lastModified) cfg.flake.inputs;
+        inputsWithDate = lib.filterAttrs (_: input: input ? lastModified) (
+          cfg.flake.inputs // { inherit (cfg) flake; }
+        );
         flakeAttrs =
           input:
           (lib.mapAttrsToList (n: v: ''${n}="${v}"'') (


### PR DESCRIPTION
We currently only expose the flake's inputs, but not the flake itself which is useful to check the currently flake via monitoring.