### PR TITLE
Add Hetzner time servers for NTP resolution

### DIFF
--- a/nixos/hardware/hetzner-online/default.nix
+++ b/nixos/hardware/hetzner-online/default.nix
@@ -31,6 +31,11 @@
 
       networking.useNetworkd = true;
       networking.useDHCP = false;
+      networking.timeServers = [
+        "ntp1.hetzner.de"
+        "ntp2.hetzner.com"
+        "ntp3.hetzner.de"
+      ];
 
       systemd.network.networks."10-uplink" = {
         matchConfig.Name = lib.mkDefault "en* eth0";


### PR DESCRIPTION
The standard configuration for the Hetzner online (robot) servers has
the standard NTP filtered.


```
sudo nix-shell -p nmap --command "nmap -sU -p 123 --script ntp-info 0.nixos.pool.ntp.org"
Starting Nmap 7.95 ( https://nmap.org ) at 2024-12-26 06:34 UTC
Nmap scan report for 0.nixos.pool.ntp.org (128.140.37.196)
Host is up (0.037s latency).
Other addresses for 0.nixos.pool.ntp.org (not scanned): 78.46.204.247 188.34.198.106 176.9.42.71
rDNS record for 128.140.37.196: ntp.heidenstedt.org

PORT    STATE         SERVICE
123/udp open|filtered ntp

Nmap done: 1 IP address (1 host up) scanned in 20.64 seconds
```

However, they provide their own NTP servers which are accessible in the
default configurations.

https://community.hetzner.com/tutorials/install-and-configure-ntp

so use these by default for the hetzner-online servers. It appears that the same
restrictions do not apply to the cloud instances.
