### PR TITLE
feat: add hostname change detection

### DIFF
--- a/nixos/common/default.nix
+++ b/nixos/common/default.nix
@@ -5,6 +5,7 @@
 
   imports = [
     ../../shared/common/flake.nix
+    ./detect-hostname-change.nix
     ./networking.nix
     ./nix.nix
     ./openssh.nix

--- a/nixos/common/detect-hostname-change.nix
+++ b/nixos/common/detect-hostname-change.nix
@@ -24,6 +24,11 @@
         exit
       fi
 
+      # Useful for automation
+      if [[ "''${EXPECTED_HOSTNAME:-}" = "$desired" ]];
+        exit
+      fi
+
       log() {
         echo "$*" >&2
       }

--- a/nixos/common/detect-hostname-change.nix
+++ b/nixos/common/detect-hostname-change.nix
@@ -1,0 +1,43 @@
+# Protection against deploying system closures to the wrong host.
+{
+  config,
+  lib,
+  ...
+}:
+{
+  options.srvos.detect-hostname-change = {
+    enable = lib.mkEnableOption "warn if the hostname changes between deploys" // {
+      default = true;
+    };
+  };
+
+  config = lib.mkIf (config.srvos.detect-hostname-change.enable && config.networking.hostName != "") {
+    system.preSwitchChecks.detectHostnameChange = ''
+      # Ignore if the system is getting installed
+      if [[ ! -e /run/current-system ]]; then
+        exit
+      fi
+
+      actual=$(< /proc/sys/kernel/hostname)
+      desired=${config.networking.hostName}
+      if [[ "$actual" = "$desired" ]]; then
+        exit
+      fi
+
+      log() {
+        echo "$*" >&2
+      }
+
+      log "WARNING: machine hostname change detected from '$actual' to '$desired'"
+      log
+      log "Are you deploying on the right host?"
+      log
+      log "Type YES to continue:"
+      read reply
+      if [[ $reply != YES ]]; then
+        echo "aborting"
+        exit 1
+      fi
+    '';
+  };
+}


### PR DESCRIPTION
NixOS is just too easy to deploy to the wrong host. Eg:

    nixos-rebuild --flake .#wronghostname --target-host root@otherhost switch

It happened to me a few times, and when I started talking about it I
got the same feedback from other people.

After this change, the user now has to confirm with YES before the
switch can happen.

To disable, set

    srvos.detect-hostname-change.enable = false;
