### PR TITLE
server: add option to re-enable documentation

### DIFF
--- a/darwin/server/default.nix
+++ b/darwin/server/default.nix
@@ -1,4 +1,9 @@
-{ lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 {
   imports = [
     ../common
@@ -6,8 +11,8 @@
   ];
 
   # not disabled by the corresponding documentation.* option
-  programs.info.enable = lib.mkDefault false;
-  programs.man.enable = lib.mkDefault false;
+  programs.info.enable = lib.mkDefault config.srvos.server.docs.enable;
+  programs.man.enable = lib.mkDefault config.srvos.server.docs.enable;
 
   # remove uninstaller, use 'nix run github:LnL7/nix-darwin#darwin-uninstaller'
   system.includeUninstaller = lib.mkDefault false;

--- a/nixos/common/default.nix
+++ b/nixos/common/default.nix
@@ -20,9 +20,6 @@
   # - for containers we currently rely on the `stage-2` init script that sets up our /etc
   boot.initrd.systemd.enable = lib.mkDefault (!config.boot.swraid.enable && !config.boot.isContainer);
 
-  # Work around for https://github.com/NixOS/nixpkgs/issues/124215
-  documentation.info.enable = false;
-
   # Don't install the /lib/ld-linux.so.2 stub. This saves one instance of nixpkgs.
   environment.ldso32 = null;
 

--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -31,7 +31,7 @@
   boot.loader.grub.configurationLimit = lib.mkDefault 5;
   boot.loader.systemd-boot.configurationLimit = lib.mkDefault 5;
 
-  documentation.nixos.enable = lib.mkDefault false;
+  documentation.nixos.enable = lib.mkDefault config.srvos.server.docs.enable;
 
   # No need for fonts on a server
   fonts.fontconfig.enable = lib.mkDefault false;

--- a/shared/server.nix
+++ b/shared/server.nix
@@ -5,21 +5,27 @@
   ...
 }:
 {
+  options.srvos.server.docs.enable = lib.mkEnableOption "" // {
+    description = ''
+      Whether to re-enable documentation disabled by the server profile.
+    '';
+  };
+  config = {
+    # List packages installed in system profile.
+    environment.systemPackages = map lib.lowPrio [
+      # no config.programs.git.package option on darwin
+      (config.programs.git.package or pkgs.gitMinimal)
+      pkgs.curl
+      pkgs.dnsutils
+      pkgs.htop
+      pkgs.jq
+      pkgs.tmux
+    ];
 
-  # List packages installed in system profile.
-  environment.systemPackages = map lib.lowPrio [
-    # no config.programs.git.package option on darwin
-    (config.programs.git.package or pkgs.gitMinimal)
-    pkgs.curl
-    pkgs.dnsutils
-    pkgs.htop
-    pkgs.jq
-    pkgs.tmux
-  ];
-
-  # Notice this also disables --help for some commands such as nixos-rebuild
-  documentation.enable = lib.mkDefault false;
-  documentation.doc.enable = lib.mkDefault false;
-  documentation.info.enable = lib.mkDefault false;
-  documentation.man.enable = lib.mkDefault false;
+    # Notice this also disables --help for some commands such as nixos-rebuild
+    documentation.enable = lib.mkDefault config.srvos.server.docs.enable;
+    documentation.doc.enable = lib.mkDefault config.srvos.server.docs.enable;
+    documentation.info.enable = lib.mkDefault config.srvos.server.docs.enable;
+    documentation.man.enable = lib.mkDefault config.srvos.server.docs.enable;
+  };
 }


### PR DESCRIPTION
Having a single option for the docs would be a bit simpler than needing to re-enable all the separate options.


I'll use this option to enable docs on the community builders.