### PR TITLE
nixos/update-diff: activationScripts -> preSwitchChecks

### DIFF
--- a/darwin/common/update-diff.nix
+++ b/darwin/common/update-diff.nix
@@ -5,8 +5,9 @@
   ];
 
   config = lib.mkIf config.srvos.update-diff.enable {
-    system.activationScripts.preActivation = {
-      inherit (config.srvos.update-diff) text;
-    };
+    system.activationScripts.preActivation.text = ''
+      incoming="''${systemConfig-}"
+      ${config.srvos.update-diff.text}
+    '';
   };
 }

--- a/nixos/common/update-diff.nix
+++ b/nixos/common/update-diff.nix
@@ -7,7 +7,10 @@
   config = lib.mkIf config.srvos.update-diff.enable {
     system.activationScripts.update-diff = {
       supportsDryActivation = true;
-      inherit (config.srvos.update-diff) text;
+      text = ''
+        incoming="''${systemConfig-}"
+        ${config.srvos.update-diff.text}
+      '';
     };
   };
 }

--- a/nixos/common/update-diff.nix
+++ b/nixos/common/update-diff.nix
@@ -5,12 +5,9 @@
   ];
 
   config = lib.mkIf config.srvos.update-diff.enable {
-    system.activationScripts.update-diff = {
-      supportsDryActivation = true;
-      text = ''
-        incoming="''${systemConfig-}"
-        ${config.srvos.update-diff.text}
-      '';
-    };
+    system.preSwitchChecks.update-diff = ''
+      incoming="''${1-}"
+      ${config.srvos.update-diff.text}
+    '';
   };
 }

--- a/shared/common/update-diff.nix
+++ b/shared/common/update-diff.nix
@@ -17,9 +17,9 @@
   config = {
     srvos.update-diff = {
       text = ''
-        if [[ -e /run/current-system ]]; then
+        if [[ -e /run/current-system && -e "''${incoming-}" ]]; then
           echo "--- diff to current-system"
-          ${pkgs.nvd}/bin/nvd --nix-bin-dir=${config.nix.package}/bin diff /run/current-system "$systemConfig"
+          ${pkgs.nvd}/bin/nvd --nix-bin-dir=${config.nix.package}/bin diff /run/current-system "''${incoming-}"
           echo "---"
         fi
       '';


### PR DESCRIPTION
Using `preSwitchChecks` makes the diff work for switch-to-configuration `boot` as well as `switch`.