### PR TITLE
nixos/server: remove root from trusted users, darwin/server: add @admin to trusted-users

### DIFF
--- a/darwin/server/default.nix
+++ b/darwin/server/default.nix
@@ -17,6 +17,9 @@
   # remove uninstaller, use 'nix run github:LnL7/nix-darwin#darwin-uninstaller'
   system.includeUninstaller = lib.mkDefault false;
 
+  # If the user is in @admin they are trusted by default.
+  nix.settings.trusted-users = [ "@admin" ];
+
   # UTC (GMT) everywhere!
   time.timeZone = lib.mkDefault "GMT";
 }

--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -60,10 +60,7 @@
   networking.hostName = lib.mkOverride 1337 ""; # lower prio than lib.mkDefault
 
   # If the user is in @wheel they are trusted by default.
-  nix.settings.trusted-users = [
-    "root"
-    "@wheel"
-  ];
+  nix.settings.trusted-users = [ "@wheel" ];
 
   security.sudo.wheelNeedsPassword = false;
 


### PR DESCRIPTION
included by default since https://github.com/NixOS/nixpkgs/commit/280e9a5ca46e6e5e266871577436abc811d22262