### PR TITLE
detect-hostname-change: improve installer detection

### DIFF
--- a/nixos/common/detect-hostname-change.nix
+++ b/nixos/common/detect-hostname-change.nix
@@ -13,13 +13,16 @@
 
   config = lib.mkIf (config.srvos.detect-hostname-change.enable && config.networking.hostName != "") {
     system.preSwitchChecks.detectHostnameChange = ''
+      actual=$(< /proc/sys/kernel/hostname)
+
       # Ignore if the system is getting installed
-      if [[ ! -e /run/current-system ]]; then
+      # https://github.com/nix-community/nixos-images/blob/2fc023e024c0a5e8e98ae94363dbf2962da10886/nix/installer.nix#L12-L13
+      if [[ ! -e /run/booted-system || "$actual" == "nixos-installer" ]]; then
         exit
       fi
 
-      actual=$(< /proc/sys/kernel/hostname)
       desired=${config.networking.hostName}
+
       if [[ "$actual" = "$desired" ]]; then
         exit
       fi


### PR DESCRIPTION
Currently the detection fails if we're trying to do an installation from a NixOS system or installer, the only time I can see that check working is if someone was trying to run `nixos-install` directly from a non-NixOS Linux distro which would also require they have Nix installed which would be super uncommon