### PR TITLE
detect-hostname-change: make shellcheck happy

### DIFF
--- a/nixos/common/detect-hostname-change.nix
+++ b/nixos/common/detect-hostname-change.nix
@@ -41,7 +41,7 @@
       log "Are you deploying on the right host?"
       log
       log "Type YES to continue:"
-      read reply
+      read -r reply
       if [[ $reply != YES ]]; then
         echo "aborting"
         exit 1


### PR DESCRIPTION
otherwise:

```
error: builder for '/nix/store/m03cxvyfj92nfvgnzxh97b8r0hchig94-pre-switch-checks.drv' failed with exit code 1;
       last 7 log lines:
       >
       > In /nix/store/68a8lky97s5406nr49scpn9baj0vd59z-pre-switch-checks/bin/pre-switch-checks line 36:
       > read reply
       > ^--^ SC2162 (info): read without -r will mangle backslashes.
       >
       > For more information:
       >   https://www.shellcheck.net/wiki/SC2162 -- read without -r will mangle backs...
       For full logs, run 'nix log /nix/store/m03cxvyfj92nfvgnzxh97b8r0hchig94-pre-switch-checks.drv'.
```

i guess it's because of https://github.com/NixOS/nixpkgs/pull/375961