### PR TITLE
nginx: disable zstd

### DIFF
--- a/nixos/mixins/nginx.nix
+++ b/nixos/mixins/nginx.nix
@@ -15,7 +15,6 @@
     recommendedOptimisation = lib.mkDefault true;
     recommendedProxySettings = lib.mkDefault true;
     recommendedTlsSettings = lib.mkDefault true;
-    recommendedZstdSettings = lib.mkDefault true;
 
     # Nginx sends all the access logs to /var/log/nginx/access.log by default.
     # instead of going to the journal!


### PR DESCRIPTION
Should not be enabled by default because important fixes are not getting merged. Trying to figure out that zstd is the culprit is tedious. Enabling the zstd module breaks SSI (used by jitsi-meet) and home-assistant.

See also:
- https://github.com/NixOS/nixpkgs/issues/359412
- https://github.com/NixOS/nixpkgs/pull/381037
- https://github.com/NixOS/nixpkgs/pull/381678