### PR TITLE
fix: sudoers are trusted in desktops too

### DIFF
--- a/darwin/common/nix.nix
+++ b/darwin/common/nix.nix
@@ -11,4 +11,7 @@
       Minute = 45;
     }
   ];
+
+  # If the user is in @admin they are trusted by default.
+  nix.settings.trusted-users = [ "@admin" ];
 }

--- a/darwin/server/default.nix
+++ b/darwin/server/default.nix
@@ -17,9 +17,6 @@
   # remove uninstaller, use 'nix run github:LnL7/nix-darwin#darwin-uninstaller'
   system.tools.darwin-uninstaller.enable = lib.mkDefault false;
 
-  # If the user is in @admin they are trusted by default.
-  nix.settings.trusted-users = [ "@admin" ];
-
   # UTC (GMT) everywhere!
   time.timeZone = lib.mkDefault "GMT";
 }

--- a/nixos/common/nix.nix
+++ b/nixos/common/nix.nix
@@ -8,6 +8,9 @@
   # where the store is host-managed.
   nix.optimise.automatic = lib.mkDefault (!config.boot.isContainer);
 
+  # If the user is in @wheel they are trusted by default.
+  nix.settings.trusted-users = [ "@wheel" ];
+
   # TODO: cargo culted.
   nix.daemonCPUSchedPolicy = lib.mkDefault "batch";
   nix.daemonIOSchedClass = lib.mkDefault "idle";

--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -59,9 +59,6 @@
   # Delegate the hostname setting to dhcp/cloud-init by default
   networking.hostName = lib.mkOverride 1337 ""; # lower prio than lib.mkDefault
 
-  # If the user is in @wheel they are trusted by default.
-  nix.settings.trusted-users = [ "@wheel" ];
-
   security.sudo.wheelNeedsPassword = false;
 
   # Enable SSH everywhere


### PR DESCRIPTION
I was surprised to see that a sudoer in a desktop environment is not trusted by default. This sane setting applies in all environments, including desktops.

@moduon MT-9339