### PR TITLE
darwin/nix: enable optimise by default

### DIFF
--- a/darwin/common/nix.nix
+++ b/darwin/common/nix.nix
@@ -5,6 +5,7 @@
   ];
 
   # do not use nix.settings.auto-optimise-store, because of https://github.com/NixOS/nix/issues/7273
+  nix.optimise.automatic = lib.mkDefault true;
   nix.optimise.interval = lib.mkDefault [
     {
       Hour = 3;


### PR DESCRIPTION
`optimise.interval` is set but service isn't enabled.