### PR TITLE
update-diff: add defaultText for update-diff for docs

### DIFF
--- a/shared/common/update-diff.nix
+++ b/shared/common/update-diff.nix
@@ -13,6 +13,7 @@
     command = lib.mkOption {
       type = lib.types.singleLineStr;
       default = "${pkgs.nvd}/bin/nvd --nix-bin-dir=${config.nix.package}/bin diff";
+      defaultText = lib.literalExpression ''"''${pkgs.nvd}/bin/nvd --nix-bin-dir=''${config.nix.package}/bin diff"'';
       description = "diff command";
     };
     text = lib.mkOption {


### PR DESCRIPTION
```
copying path '/nix/store/c353hld7p5h24rfjl32zjhv3m2gh9rij-source' from 'https://nix-community.cachix.org'...
trace: evaluation warning: Attempt to evaluate package pkgs.nvd in option documentation; this is not supported and will eventually be an error. Use `mkPackageOption{,MD}` or `literalExpression` instead.
error:
------8<------8<-----
       error: attribute 'nix' missing
       at /nix/store/c353hld7p5h24rfjl32zjhv3m2gh9rij-source/shared/common/update-diff.nix:15:54:
           14|       type = lib.types.singleLineStr;
           15|       default = "${pkgs.nvd}/bin/nvd --nix-bin-dir=${config.nix.package}/bin diff";
             |                                                      ^
           16|       description = "diff command";
```

fix renders manual as such:

```man
       srvos.update-diff.command
           diff command

           Type: (optionally newline-terminated) single-line string

           Default: "${pkgs.nvd}/bin/nvd --nix-bin-dir=${config.nix.package}/bin diff"

           Declared by:
               /nix/store/abvydm0fxbmgbmh89m76zl1vlglkws1n-source/shared/common/update-diff.nix
```