### PR TITLE
prometheus: add host label to TelegrafDown alerts

### DIFF
--- a/nixos/roles/prometheus/default-alerts.nix
+++ b/nixos/roles/prometheus/default-alerts.nix
@@ -115,7 +115,7 @@
       };
 
       TelegrafDown = {
-        expr = ''min(up{job=~"telegraf",type!='mobile'}) by (source, job, instance, org) == 0'';
+        expr = ''label_replace(min(up{job=~"telegraf",type!='mobile'}) by (source, job, instance, org), "host", "$1", "instance", "([^.:]+).*") == 0'';
         for = "3m";
         annotations.description = "{{$labels.instance}}: telegraf exporter from {{$labels.instance}} is down";
       };

--- a/nixos/roles/prometheus/default-alerts.nix
+++ b/nixos/roles/prometheus/default-alerts.nix
@@ -115,7 +115,7 @@
       };
 
       TelegrafDown = {
-        expr = ''label_replace(min(up{job=~"telegraf",type!='mobile'}) by (source, job, instance, org), "host", "$1", "instance", "([^.:]+).*") == 0'';
+        expr = ''label_replace(label_replace(min(up{job=~"telegraf",type!='mobile'}) by (source, job, instance, org), "host", "$1", "instance", "^\\[([^\\]]+)\\]:[0-9]+$"), "host", "$1", "instance", "^([^.:]+).*") == 0'';
         for = "3m";
         annotations.description = "{{$labels.instance}}: telegraf exporter from {{$labels.instance}} is down";
       };


### PR DESCRIPTION
Extract the host name from the instance label (e.g., "rauter.r:9273" -> "rauter") to enable proper grouping by host in Alertmanager routing rules.