### PR TITLE
fix: allow failing ssh-ng substituters

### DIFF
--- a/shared/common/nix.nix
+++ b/shared/common/nix.nix
@@ -5,6 +5,7 @@
 
   # Fallback quickly if substituters are not available.
   nix.settings.connect-timeout = lib.mkDefault 5;
+  nix.settings.fallback = true;
 
   # Enable flakes
   nix.settings.experimental-features = [


### PR DESCRIPTION
See details in
https://github.com/NixOS/nix/issues/3514#issuecomment-2313160224.
