### PR TITLE
nixos/server: fix evaluation on old commits

### DIFF
--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -88,32 +88,37 @@
       AllowHibernation=no
     '';
   }
-  // lib.optionalAttrs (lib.versionAtLeast (lib.versions.majorMinor lib.version) "25.11") {
-    # For more detail, see:
-    #   https://0pointer.de/blog/projects/watchdog.html
-    settings.Manager = {
-      # systemd will send a signal to the hardware watchdog at half
-      # the interval defined here, so every 7.5s.
-      # If the hardware watchdog does not get a signal for 15s,
-      # it will forcefully reboot the system.
-      RuntimeWatchdogSec = lib.mkDefault "15s";
-      # Forcefully reboot if the final stage of the reboot
-      # hangs without progress for more than 30s.
-      # For more info, see:
-      #   https://utcc.utoronto.ca/~cks/space/blog/linux/SystemdShutdownWatchdog
-      RebootWatchdogSec = lib.mkDefault "30s";
-      # Forcefully reboot when a host hangs after kexec.
-      # This may be the case when the firmware does not support kexec.
-      KExecWatchdogSec = lib.mkDefault "1m";
-    };
-  }
-  // lib.optionalAttrs (lib.versionOlder (lib.versions.majorMinor lib.version) "25.11") {
-    watchdog = {
-      runtimeTime = lib.mkDefault "15s";
-      rebootTime = lib.mkDefault "30s";
-      kexecTime = lib.mkDefault "1m";
-    };
-  };
+  // (
+    # TODO: remove when 25.05 is deprecated
+    if options.systemd ? settings then
+      {
+        # For more detail, see:
+        #   https://0pointer.de/blog/projects/watchdog.html
+        settings.Manager = {
+          # systemd will send a signal to the hardware watchdog at half
+          # the interval defined here, so every 7.5s.
+          # If the hardware watchdog does not get a signal for 15s,
+          # it will forcefully reboot the system.
+          RuntimeWatchdogSec = lib.mkDefault "15s";
+          # Forcefully reboot if the final stage of the reboot
+          # hangs without progress for more than 30s.
+          # For more info, see:
+          #   https://utcc.utoronto.ca/~cks/space/blog/linux/SystemdShutdownWatchdog
+          RebootWatchdogSec = lib.mkDefault "30s";
+          # Forcefully reboot when a host hangs after kexec.
+          # This may be the case when the firmware does not support kexec.
+          KExecWatchdogSec = lib.mkDefault "1m";
+        };
+      }
+    else
+      {
+        watchdog = {
+          runtimeTime = lib.mkDefault "15s";
+          rebootTime = lib.mkDefault "30s";
+          kexecTime = lib.mkDefault "1m";
+        };
+      }
+  );
 
   # Make sure the serial console is visible in qemu when testing the server configuration
   # with nixos-rebuild build-vm


### PR DESCRIPTION
#673 causes evaluation to fail on commits like https://github.com/NixOS/nixpkgs/commit/41da1e3ea8e23e094e5e3eeb1e6b830468a7399e as the NixOS version is 25.11 but does not include https://github.com/NixOS/nixpkgs/commit/1adf0f56ff95cae9db9fb198950b5c10ba52635b