### PR TITLE
feat(resolved): disable llmnr on server profile

### DIFF
--- a/nixos/server/default.nix
+++ b/nixos/server/default.nix
@@ -63,6 +63,9 @@
   # Enable SSH everywhere
   services.openssh.enable = true;
 
+  # Prevent LLMNR poisoning attacks
+  services.resolved.llmnr = lib.mkDefault "false";
+
   # UTC everywhere!
   time.timeZone = lib.mkDefault "UTC";
 


### PR DESCRIPTION
This change disables LLMNR in the server profile which is vulnerable to [poisoning attacks](https://attack.mitre.org/techniques/T1557/001/).

- systemd discussing [disabling by default ](https://github.com/systemd/systemd/pull/28263)

- ubuntu 24.04+ has [disabled llmnr by default 
](https://launchpad.net/ubuntu/+source/systemd/255-1ubuntu1)

- fedora server (42) and opensuse (15) sets it to "resolve" which allows querying for responses, but will not register itself nor respond to requests.

- rhel / suse only use network manager which configures glibc dns resolver directly (no resolved or llmnr)