### PR TITLE
vultr: support zfs root on VMs

### DIFF
--- a/docs/nixos/hardware.md
+++ b/docs/nixos/hardware.md
@@ -16,6 +16,14 @@ Hardware configuration for <https://www.digitalocean.com/> instances.
 
 Enables cloud-init but turns off non-working dhcp.
 
+### [`nixosModules.hardware-vultr-vm`]({{ repo_url }}/blob/main/nixos/hardware/vultr/vm.nix)
+
+Hardware configuration for Vultr Cloud Compute instances.
+
+Enables cloud-init with the Vultr datasource and configures QEMU, GRUB, and
+VirtIO support. ZFS root pools are discovered through partition UUIDs because
+Vultr disks do not expose stable `by-id` links.
+
 ### [`nixosModules.hardware-hetzner-cloud`]({{ repo_url }}/blob/main/nixos/hardware/hetzner-cloud/default.nix)
 
 Hardware configuration for <https://www.hetzner.com/cloud> instances.

--- a/nixos/hardware/vultr/vm.nix
+++ b/nixos/hardware/vultr/vm.nix
@@ -1,4 +1,9 @@
-{ modulesPath, lib, ... }:
+{
+  modulesPath,
+  lib,
+  config,
+  ...
+}:
 {
   imports = [
     ./.
@@ -6,6 +11,56 @@
     "${modulesPath}/profiles/qemu-guest.nix"
   ];
 
-  boot.loader.grub.enable = true;
-  boot.loader.grub.devices = lib.mkDefault [ "/dev/vda" ];
+  services.cloud-init.settings = {
+    # cloud-init treats a ZFS dataset as a block filesystem and cannot expand it.
+    cloud_init_modules = lib.mkIf config.boot.zfs.enabled (
+      lib.mkOverride 900 [
+        "migrator"
+        "seed_random"
+        "bootcmd"
+        "write-files"
+        "update_hostname"
+        "resolv_conf"
+        "ca-certs"
+        "rsyslog"
+        "users-groups"
+      ]
+    );
+
+    # Vultr VM vendor data attempts to mutate NixOS-managed SSH configuration.
+    cloud_config_modules = lib.mkForce [
+      "disk_setup"
+      "mounts"
+      "ssh-import-id"
+      "timezone"
+      "disable-ec2-metadata"
+      "runcmd"
+      "ssh"
+    ];
+
+    # Vultr VM vendor scripts require /bin/bash and imperatively change system state.
+    cloud_final_modules = lib.mkForce [
+      "rightscale_userdata"
+      "scripts-per-once"
+      "scripts-per-boot"
+      "scripts-per-instance"
+      "scripts-user"
+      "ssh-authkey-fingerprints"
+      "phone-home"
+      "final-message"
+      "power-state-change"
+    ];
+  };
+
+  boot = {
+    # Vultr system disks use virtio-blk and may appear too late for ZFS root import.
+    initrd.kernelModules = [
+      "virtio_pci"
+      "virtio_blk"
+    ];
+    loader.grub.enable = true;
+    loader.grub.devices = lib.mkDefault [ "/dev/vda" ];
+    # Vultr disks do not expose stable by-id links.
+    zfs.devNodes = lib.mkDefault "/dev/disk/by-partuuid";
+  };
 }


### PR DESCRIPTION
Support reliable ZFS root boots on Vultr Cloud Compute, where VirtIO system disks lack stable `by-id` links and Vultr vendor data performs mutations incompatible with NixOS. The VM profile now loads VirtIO block drivers before root import, discovers ZFS devices by partition UUID, and limits cloud-init modules that cannot safely handle NixOS-managed SSH configuration, vendor scripts, or ZFS datasets. Verified on a disposable Vultr VM with a clean cloud-init run and cold reboot: all cloud-init units succeeded, the ZFS root pool imported healthy, networking and SSH persisted, and current and stable evaluation checks passed.