### PR TITLE
nix-experimental: enable dynamic-derivations

### DIFF
--- a/darwin/mixins/nix-experimental.nix
+++ b/darwin/mixins/nix-experimental.nix
@@ -28,6 +28,9 @@
     # derivation attribute to true. An impure derivation can have differing
     # outputs each time it is built.
     "impure-derivations"
+
+    # Allow derivations whose output is a .drv that is then built (builtins.outputOf).
+    "dynamic-derivations"
   ]
   ++ lib.optionals (lib.versionAtLeast (lib.versions.majorMinor config.nix.package.version) "2.29") [
     "blake3-hashes"

--- a/nixos/mixins/nix-experimental.nix
+++ b/nixos/mixins/nix-experimental.nix
@@ -32,6 +32,9 @@
     # derivation attribute to true. An impure derivation can have differing
     # outputs each time it is built.
     "impure-derivations"
+
+    # Allow derivations whose output is a .drv that is then built (builtins.outputOf).
+    "dynamic-derivations"
   ]
   ++ lib.optionals (lib.versionAtLeast (lib.versions.majorMinor config.nix.package.version) "2.29") [
     "blake3-hashes"


### PR DESCRIPTION
Needed daemon-side for .drv-producing derivations. Complements ca-derivations.